### PR TITLE
Add email validator with tests

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/util/EmailValidator.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/util/EmailValidator.kt
@@ -1,0 +1,12 @@
+package dev.butov.anton.util
+
+private val EMAIL_REGEX = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$".toRegex()
+
+/**
+ * Validate email address format.
+ *
+ * @return true if the email looks valid according to a simple regex.
+ */
+fun isValidEmail(email: String): Boolean {
+    return EMAIL_REGEX.matches(email)
+}

--- a/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/util/EmailValidatorTest.kt
+++ b/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/util/EmailValidatorTest.kt
@@ -1,0 +1,26 @@
+package dev.butov.anton.util
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EmailValidatorTest {
+    @Test
+    fun validEmailReturnsTrue() {
+        assertTrue(isValidEmail("user@example.com"))
+    }
+
+    @Test
+    fun invalidEmailReturnsFalse() {
+        val invalidEmails = listOf(
+            "plainaddress",
+            "missing-at.com",
+            "user@.com",
+            "user@com",
+            "user@domain..com"
+        )
+        for (email in invalidEmails) {
+            assertFalse(isValidEmail(email), "Expected '$email' to be invalid")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a simple email validation utility
- add unit tests for email validation logic

## Testing
- `gradle composeApp:wasmJsTest` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686a1b60b7a88320870ab6c9c89067b9