### PR TITLE
Add background color for OutlinedTextField

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/ContactMe.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/ContactMe.kt
@@ -43,6 +43,8 @@ private fun SendMessageBlock(modifier: Modifier) {
                 focusedLabelColor = Colors.primary,
                 unfocusedLabelColor = Colors.primary.copy(alpha = 0.4f),
                 cursorColor = Colors.primary,
+                focusedContainerColor = Colors.surface,
+                unfocusedContainerColor = Colors.surface,
             )
 
         Row(


### PR DESCRIPTION
## Summary
- customize the container color of every `OutlinedTextField` in `ContactMe`

## Testing
- `./gradlew tasks --all` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_686aba86d75483209511a806fa7d59d9