### PR TITLE
Fix PhotoBlock layout

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/PhotoBlock.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/PhotoBlock.kt
@@ -8,9 +8,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import antonbutov.composeapp.generated.resources.Res
 import antonbutov.composeapp.generated.resources.butov
 import dev.butov.anton.Colors
@@ -22,21 +23,21 @@ import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun PhotoBlock() {
-    Box(modifier = Modifier.height(550.dp).fillMaxWidth()) {
-        Im(Modifier.align(Alignment.BottomStart))
-        Icon(
-            painter = painterResource(Res.drawable.butov),
-            contentDescription = null,
-            modifier =
-                Modifier
-                    .align(Alignment.BottomEnd),
-            tint = Color.Unspecified,
-        )
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        Box(modifier = Modifier.height(550.dp).fillMaxWidth()) {
+            Im(Modifier.align(Alignment.BottomStart), maxWidth)
+            Icon(
+                painter = painterResource(Res.drawable.butov),
+                contentDescription = null,
+                modifier = Modifier.align(Alignment.BottomEnd).height(550.dp),
+                tint = Color.Unspecified,
+            )
+        }
     }
 }
 
 @Composable
-private fun Im(modifier: Modifier) {
+private fun Im(modifier: Modifier, width: Dp) {
     Column(modifier = modifier) {
         val firstText =
             buildAnnotatedString {
@@ -50,8 +51,13 @@ private fun Im(modifier: Modifier) {
                     append("and I'm a ")
                 }
                 FullStyle {
-                    append("Senior Android ")
+                    append("Senior ")
                 }
+                if (width < 700.dp) append("\n")
+                FullStyle {
+                    append("Android ")
+                }
+                if (width < 900.dp) append("\n")
                 FullStyleUnderline {
                     append("Developer")
                 }


### PR DESCRIPTION
## Summary
- make PhotoBlock responsive by adjusting text line breaks instead of stacking

## Testing
- `gradle tasks --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686ac7fdfee083208fd6efec18435c67