### PR TITLE
Refactor SendMessageViewModel to use SendMessageState

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModel.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModel.kt
@@ -1,24 +1,47 @@
 package dev.butov.anton.subscreens.sendMessage
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 
+/** View model controlling SendMessage screen state. */
 class SendMessageViewModel {
-    var name by mutableStateOf("")
-        private set
-    var email by mutableStateOf("")
-        private set
-    var message by mutableStateOf("")
+    /** Current state of the screen. */
+    var state: SendMessageState by mutableStateOf(SendMessageState.Edit("", "", ""))
         private set
 
+    /** Current name value from [state] or empty if not editing. */
+    val name: String
+        get() = (state as? SendMessageState.Edit)?.name ?: ""
+
+    /** Current email value from [state] or empty if not editing. */
+    val email: String
+        get() = (state as? SendMessageState.Edit)?.email ?: ""
+
+    /** Current message value from [state] or empty if not editing. */
+    val message: String
+        get() = (state as? SendMessageState.Edit)?.message ?: ""
+
+    /** Update name when in [SendMessageState.Edit] state. */
     fun onNameChange(value: String) {
-        name = value
+        val current = state
+        if (current is SendMessageState.Edit) {
+            state = current.copy(name = value)
+        }
     }
 
+    /** Update email when in [SendMessageState.Edit] state. */
     fun onEmailChange(value: String) {
-        email = value
+        val current = state
+        if (current is SendMessageState.Edit) {
+            state = current.copy(email = value)
+        }
     }
 
+    /** Update message when in [SendMessageState.Edit] state. */
     fun onMessageChange(value: String) {
-        message = value
-    }
-}
+        val current = state
+        if (current is SendMessageState.Edit) {
+            state = current.copy(message = value)
+        }
+    }}

--- a/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModelTest.kt
+++ b/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModelTest.kt
@@ -1,0 +1,36 @@
+package dev.butov.anton.subscreens.sendMessage
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SendMessageViewModelTest {
+    @Test
+    fun `initial state is empty edit`() {
+        val viewModel = SendMessageViewModel()
+        assertEquals(SendMessageState.Edit("", "", ""), viewModel.state)
+    }
+
+    @Test
+    fun `name change updates state`() {
+        val viewModel = SendMessageViewModel()
+        viewModel.onNameChange("John")
+        assertEquals("John", viewModel.name)
+        assertEquals(SendMessageState.Edit("John", "", ""), viewModel.state)
+    }
+
+    @Test
+    fun `email change updates state`() {
+        val viewModel = SendMessageViewModel()
+        viewModel.onEmailChange("e@ma.il")
+        assertEquals("e@ma.il", viewModel.email)
+        assertEquals(SendMessageState.Edit("", "e@ma.il", ""), viewModel.state)
+    }
+
+    @Test
+    fun `message change updates state`() {
+        val viewModel = SendMessageViewModel()
+        viewModel.onMessageChange("hello")
+        assertEquals("hello", viewModel.message)
+        assertEquals(SendMessageState.Edit("", "", "hello"), viewModel.state)
+    }
+}


### PR DESCRIPTION
## Summary
- adopt state-based model in `SendMessageViewModel`
- cover ViewModel logic with unit tests

## Testing
- `gradle test --no-daemon` *(fails: Plugin was not found because network access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_686ec7ceb53c832fa1a9aed1f310f6ac