### PR TITLE
Update SendMessageViewModel async

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModel.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModel.kt
@@ -4,10 +4,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
 
 class SendMessageViewModel(
     private val repository: SendMessageRepository = FormspreeSendMessageRepository(),
-) {
+) : ViewModel() {
     var state: SendMessageState by mutableStateOf(SendMessageState.Edit("", "", ""))
         private set
 
@@ -45,12 +47,13 @@ class SendMessageViewModel(
     }
 
     fun send() {
-
-        try {
-            repository.send(name, email, message)
-            state = SendMessageState.Ok
-        } catch (_: Exception) {
-            state = (state as SendMessageState.Edit).copy(isError = true)
+        viewModelScope.launch {
+            try {
+                repository.send(name, email, message)
+                state = SendMessageState.Ok
+            } catch (_: Exception) {
+                state = (state as SendMessageState.Edit).copy(isError = true)
+            }
         }
     }
 }

--- a/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModelTest.kt
+++ b/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModelTest.kt
@@ -1,5 +1,6 @@
 package dev.butov.anton.subscreens.sendMessage
 
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -52,6 +53,7 @@ class SendMessageViewModelTest {
             viewModel.onMessageChange("m")
 
             viewModel.send()
+            advanceUntilIdle()
 
             assertEquals(SendMessageState.Ok, viewModel.state)
         }
@@ -72,6 +74,7 @@ class SendMessageViewModelTest {
             val viewModel = SendMessageViewModel(repo)
 
             viewModel.send()
+            advanceUntilIdle()
 
             assertEquals(true, viewModel.isError)
         }


### PR DESCRIPTION
## Summary
- turn `SendMessageViewModel` into a real `ViewModel` and use `viewModelScope`
- launch message sending in a coroutine
- wait for coroutines in the unit tests

## Testing
- `gradle check` *(fails: ChromeHeadless missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878722e5374832088a7907e619e15c1