### PR TITLE
Add Accept header to Formspree requests

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageRepository.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageRepository.kt
@@ -5,6 +5,8 @@ import io.ktor.client.engine.js.Js
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
 import io.ktor.http.Parameters
 
 interface SendMessageRepository {
@@ -34,6 +36,7 @@ class FormspreeSendMessageRepository(
                     },
                 ),
             )
+            header(HttpHeaders.Accept, "application/json")
         }.status.value < 400
     }
 }

--- a/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageRepositoryTest.kt
+++ b/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageRepositoryTest.kt
@@ -15,9 +15,11 @@ class SendMessageRepositoryTest {
     fun `send posts form data`() =
         runTest {
             var capturedBody: Any? = null
+            var capturedAccept: String? = null
             val engine =
                 MockEngine { request ->
                     capturedBody = request.body
+                    capturedAccept = request.headers["Accept"]
                     respond("", HttpStatusCode.Accepted)
                 }
             val client = HttpClient(engine)
@@ -30,5 +32,6 @@ class SendMessageRepositoryTest {
             assertEquals(listOf("john"), parameters.getAll("name"))
             assertEquals(listOf("a@b.c"), parameters.getAll("email"))
             assertEquals(listOf("hello"), parameters.getAll("message"))
+            assertEquals("application/json", capturedAccept)
         }
 }

--- a/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModelTest.kt
+++ b/composeApp/src/wasmJsTest/kotlin/dev/butov/anton/subscreens/sendMessage/SendMessageViewModelTest.kt
@@ -45,7 +45,7 @@ class SendMessageViewModelTest {
                         name: String,
                         email: String,
                         message: String,
-                    ) {}
+                    ): Boolean = true
                 }
             val viewModel = SendMessageViewModel(repo)
             viewModel.onNameChange("n")
@@ -67,7 +67,7 @@ class SendMessageViewModelTest {
                         name: String,
                         email: String,
                         message: String,
-                    ) {
+                    ): Boolean {
                         throw RuntimeException()
                     }
                 }


### PR DESCRIPTION
## Summary
- specify `Accept: application/json` for Formspree client requests to avoid fetch failures
- assert Accept header in repository tests and fix view-model tests

## Testing
- `gradle wasmJsTest --console=plain` *(fails: Lock file was changed. Run the `kotlinUpgradeYarnLock` task to actualize lock file)*

------
https://chatgpt.com/codex/tasks/task_e_688e5b4bbf5c8320934c6c41e4cfdf00