### PR TITLE
Add current year helper

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -71,6 +71,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(libs.coroutines.core)
             implementation(libs.ktor.client.core)
+            implementation(libs.kotlinx.datetime)
             //  implementation("io.coil-kt.coil3:coil-compose:3.2.0")
             // implementation("io.coil-kt:coil-svg:2.1.0")
         }

--- a/composeApp/src/commonMain/kotlin/dev/butov/anton/CurrentYear.kt
+++ b/composeApp/src/commonMain/kotlin/dev/butov/anton/CurrentYear.kt
@@ -1,0 +1,8 @@
+package dev.butov.anton
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+val currentYear: Int =
+    Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).year

--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/Technology.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/Technology.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.butov.anton.Colors
 import dev.butov.anton.TechnologiesEnum
+import dev.butov.anton.currentYear
 import dev.butov.anton.myiconpack.*
 
 @Composable
@@ -75,7 +76,7 @@ private fun TechnologyKotlin() {
             Modifier
                 .padding(start = 15.dp, top = 14.dp),
         technology = TechnologiesEnum.Kotlin,
-        experience = "5 years", // todo by now
+        experience = "${currentYear - 2020} years",
     )
 }
 
@@ -86,7 +87,7 @@ private fun TechnologyJava() {
             Modifier
                 .padding(start = 15.dp, top = 10.dp),
         technology = TechnologiesEnum.Java,
-        experience = "5 years", // todo by now
+        experience = "${currentYear - 2020} years",
     )
 }
 
@@ -97,7 +98,7 @@ private fun TechnologyCompose() {
             Modifier
                 .padding(start = 13.dp, top = 10.dp),
         technology = TechnologiesEnum.JetpackCompose,
-        experience = "3 years", // todo by now
+        experience = "${currentYear - 2022} years",
     )
 }
 
@@ -108,7 +109,7 @@ private fun TechnologyDagger() {
             Modifier
                 .padding(start = 12.dp, top = 10.dp),
         technology = TechnologiesEnum.Dagger,
-        experience = "5 years", // todo by now
+        experience = "${currentYear - 2020} years",
     )
 }
 
@@ -119,7 +120,7 @@ private fun TechnologyCleanArchitecture() {
             Modifier
                 .padding(start = 13.dp, top = 10.dp),
         technology = TechnologiesEnum.CleanArchitecture,
-        experience = "5 years", // todo by now
+        experience = "${currentYear - 2020} years",
     )
 }
 
@@ -130,7 +131,7 @@ private fun TechnologyTDD() {
             Modifier
                 .padding(start = 13.dp, top = 10.dp),
         technology = TechnologiesEnum.TDD,
-        experience = "5 years", // todo by now
+        experience = "${currentYear - 2020} years",
     )
 }
 
@@ -141,7 +142,7 @@ private fun TechnologyKMP() {
             Modifier
                 .padding(start = 13.dp, top = 10.dp),
         technology = TechnologiesEnum.KMP,
-        experience = "3 years", // todo by now
+        experience = "${currentYear - 2022} years",
     )
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotlin = "2.1.21"
 ktlint = "12.3.0"
 ktor = "3.2.1"
 coroutines = "1.10.2"
+kotlinx-datetime = "0.6.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -18,6 +19,7 @@ ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }


### PR DESCRIPTION
## Summary
- compute current year using `kotlinx-datetime`
- calculate technology experience from the current year
- restore project timelines to fixed year ranges

## Testing
- `./gradlew check`
- `./gradlew assemble`


------
https://chatgpt.com/codex/tasks/task_e_689f5baabe0c8320bd17b0f97da2aedb