### PR TITLE
Split main column into navigable sections

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/App.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/App.kt
@@ -14,7 +14,9 @@ import antonbutov.composeapp.generated.resources.Res
 import antonbutov.composeapp.generated.resources.butov
 import antonbutov.composeapp.generated.resources.redBack
 import dev.butov.anton.myiconpack.*
-import dev.butov.anton.screens.MainColumn
+import dev.butov.anton.screens.Contacts
+import dev.butov.anton.screens.Home
+import dev.butov.anton.screens.Projects
 import dev.butov.anton.uikit.*
 import org.jetbrains.compose.resources.painterResource
 
@@ -46,8 +48,14 @@ fun App() {
                                 contentDescription = null,
                                 contentScale = ContentScale.FillWidth,
                             )
-                            MainColumn()
+                            Home()
                         }
+                    }
+                    item {
+                        Projects()
+                    }
+                    item {
+                        Contacts()
                     }
                 }
                 val scrollbarStyle =

--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/screens/MainColumn.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/screens/MainColumn.kt
@@ -12,69 +12,47 @@ import dev.butov.anton.tools.CenteredLayout
 import dev.butov.anton.uikit.Message
 
 @Composable
-fun MainColumn() {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        CenteredLayout {
-            Spacer(Modifier.size(50.dp))
-        }
-        CenteredLayout {
-            Header()
-        }
-        CenteredLayout {
-            Spacer(modifier = Modifier.size(50.dp))
-        }
+fun Home() {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        CenteredLayout { Spacer(Modifier.size(50.dp)) }
+        CenteredLayout { Header() }
+        CenteredLayout { Spacer(modifier = Modifier.size(50.dp)) }
         CenteredLayout {
             Box {
                 PhotoBlock()
                 BackGroundRectangles()
             }
         }
-        CenteredLayout {
-            Spacer(Modifier.size(60.dp))
-        }
-        CenteredLayout {
-            Technologies()
-        }
-        CenteredLayout {
-            Spacer(Modifier.size(150.dp))
-        }
-        CenteredLayout {
-            MyProjects()
-        }
-        CenteredLayout {
-            Spacer(Modifier.size(110.dp))
-        }
-        CenteredLayout {
-            Message(Modifier.align(Alignment.CenterHorizontally))
-        }
-        CenteredLayout {
-            Spacer(Modifier.size(130.dp))
-        }
-        CenteredLayout {
-            ContactMe()
-        }
-        CenteredLayout {
-            Spacer(Modifier.size(110.dp))
-        }
+        CenteredLayout { Spacer(Modifier.size(60.dp)) }
+        CenteredLayout { Technologies() }
+        CenteredLayout { Spacer(Modifier.size(150.dp)) }
+    }
+}
+
+@Composable
+fun Projects() {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        CenteredLayout { MyProjects() }
+    }
+}
+
+@Composable
+fun Contacts() {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        CenteredLayout { Spacer(Modifier.size(110.dp)) }
+        CenteredLayout { Message(Modifier.align(Alignment.CenterHorizontally)) }
+        CenteredLayout { Spacer(Modifier.size(130.dp)) }
+        CenteredLayout { ContactMe() }
+        CenteredLayout { Spacer(Modifier.size(110.dp)) }
         CenteredLayout(
             modifier = Modifier.background(Colors.surface),
             renderLines = false,
         ) {
             Footer()
         }
-        CenteredLayout {
-            Spacer(Modifier.size(50.dp))
-        }
-        CenteredLayout {
-            Spacer(Modifier.size(30.dp))
-        }
-        CenteredLayout {
-            Smirnov()
-        }
-        CenteredLayout {
-            Spacer(Modifier.size(30.dp))
-        }
+        CenteredLayout { Spacer(Modifier.size(50.dp)) }
+        CenteredLayout { Spacer(Modifier.size(30.dp)) }
+        CenteredLayout { Smirnov() }
+        CenteredLayout { Spacer(Modifier.size(30.dp)) }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `MainColumn` with `Home`, `Projects`, and `Contacts` composables
- Render each section as its own LazyColumn item for easier navigation

## Testing
- `./gradlew build` *(fails: Errors occurred during launch of browser for testing. Please make sure that you have installed browsers.)*

------
https://chatgpt.com/codex/tasks/task_e_689f758ea3688320a5b5138a74fe1c2e