### PR TITLE
Enable horizontal scrolling for narrow screens

### DIFF
--- a/composeApp/src/wasmJsMain/resources/styles.css
+++ b/composeApp/src/wasmJsMain/resources/styles.css
@@ -3,8 +3,10 @@ html, body {
     height: 100%;
     margin: 0;
     padding: 0;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
     background: #0B0B0B;
+    min-width: 1000px;
 }
 
 /* Стили для полосы прокрутки */
@@ -26,4 +28,5 @@ html, body {
 
 canvas {
     background: #0B0B0B;
+    min-width: 1000px;
 }


### PR DESCRIPTION
## Summary
- Allow horizontal scroll and enforce a 1000px minimum width for the app canvas and body.

## Testing
- `./gradlew build` *(fails: Cannot infer type for this parameter in MenuViewModelTest.kt)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dade52a48320b51f94c11f2231b5