### PR TITLE
fix: add onClick handlers to open external links in subscreens

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/Footer.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/Footer.kt
@@ -1,5 +1,6 @@
 package dev.butov.anton.subscreens
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.onClick
@@ -54,12 +55,14 @@ fun Footer() {
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun EMail(modifier: Modifier = Modifier) {
     Button(
-        modifier = modifier.onClick(onClick = { 
-            window.open("mailto:mail@antonbutov.com", "_blank") 
-        })
+        modifier =
+            modifier.onClick(onClick = {
+                window.open("mailto:mail@antonbutov.com", "_blank")
+            }),
     ) {
         Text(
             text = "mail@antonbutov.com",
@@ -68,13 +71,15 @@ private fun EMail(modifier: Modifier = Modifier) {
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun Messagers() {
     Row {
         Button(
-            modifier = Modifier.onClick(onClick = { 
-                window.open("https://t.me/antonbutov", "_blank") 
-            })
+            modifier =
+                Modifier.onClick(onClick = {
+                    window.open("https://t.me/antonbutov", "_blank")
+                }),
         ) {
             Icon(
                 AntonIcons.Teleg,
@@ -83,9 +88,10 @@ private fun Messagers() {
         }
         Spacer(modifier = Modifier.width(10.dp))
         Button(
-            modifier = Modifier.onClick(onClick = { 
-                window.open("https://github.com/AntonButov", "_blank") 
-            })
+            modifier =
+                Modifier.onClick(onClick = {
+                    window.open("https://github.com/AntonButov", "_blank")
+                }),
         ) {
             Icon(
                 imageVector = AntonIcons.Github,
@@ -94,9 +100,10 @@ private fun Messagers() {
         }
         Spacer(modifier = Modifier.size(10.dp))
         Button(
-            modifier = Modifier.onClick(onClick = { 
-                window.open("https://www.linkedin.com/in/antonbutov", "_blank") 
-            })
+            modifier =
+                Modifier.onClick(onClick = {
+                    window.open("https://www.linkedin.com/in/antonbutov", "_blank")
+                }),
         ) {
             Icon(
                 imageVector = AntonIcons.Ln,

--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/MyProjects.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/MyProjects.kt
@@ -1,5 +1,6 @@
 package dev.butov.anton.subscreens
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
@@ -88,7 +89,7 @@ private fun ProjectDaggerDsl() {
                 { TechnologyButton(TechnologiesEnum.KotlinPoet) },
                 { TechnologyButton(TechnologiesEnum.KSP) },
             ),
-        onClick = { window.open("https://github.com/AntonButov/dagger-dsl", "_blank") }
+        onClick = { window.open("https://github.com/AntonButov/dagger-dsl", "_blank") },
     )
 }
 
@@ -104,7 +105,7 @@ private fun ProjectGo() {
                 { TechnologyButton(TechnologiesEnum.Java) },
                 { TechnologyButton(TechnologiesEnum.Dagger) },
             ),
-        onClick = { window.open("https://go.yandex/#download-app", "_blank") }
+        onClick = { window.open("https://go.yandex/#download-app", "_blank") },
     )
 }
 
@@ -119,7 +120,7 @@ private fun ProjectAlerton() {
                 { TechnologyButton(TechnologiesEnum.WEBRTC) },
                 { TechnologyButton(TechnologiesEnum.JetpackCompose) },
             ),
-        onClick = { window.open("https://play.google.com/store/apps/details?id=ru.profsoft.alerton", "_blank") }
+        onClick = { window.open("https://play.google.com/store/apps/details?id=ru.profsoft.alerton", "_blank") },
     )
 }
 
@@ -134,12 +135,11 @@ private fun ProjectIva() {
                 { TechnologyButton(TechnologiesEnum.WEBRTC) },
                 { TechnologyButton(TechnologiesEnum.JetpackCompose) },
             ),
-        onClick = { window.open("https://iva.ru/ru/products/iva-connect/", "_blank") }
+        onClick = { window.open("https://iva.ru/ru/products/iva-connect/", "_blank") },
     )
 }
 
-
-
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun Project(
     painter: Painter,
@@ -149,14 +149,15 @@ private fun Project(
     onClick: () -> Unit,
 ) {
     Box(
-        modifier = Modifier
-            .height(270.dp)
-            .width(300.dp)
-            .clip(MaterialTheme.shapes.small)
-            .background(Colors.surface.copy(alpha = 0.97f).compositeOver(Colors.red))
-            .border(1.dp, Colors.primary.copy(alpha = 0.05f), MaterialTheme.shapes.small)
-            .padding(horizontal = 14.dp, vertical = 16.dp)
-            .onClick(onClick = onClick),
+        modifier =
+            Modifier
+                .height(270.dp)
+                .width(300.dp)
+                .clip(MaterialTheme.shapes.small)
+                .background(Colors.surface.copy(alpha = 0.97f).compositeOver(Colors.red))
+                .border(1.dp, Colors.primary.copy(alpha = 0.05f), MaterialTheme.shapes.small)
+                .padding(horizontal = 14.dp, vertical = 16.dp)
+                .onClick(onClick = onClick),
     ) {
         Row {
             Icon(

--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/Smirnov.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/subscreens/Smirnov.kt
@@ -1,5 +1,6 @@
 package dev.butov.anton.subscreens
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.content.MediaType.Companion.Text
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -24,6 +25,7 @@ import dev.butov.anton.myiconpack.Ss
 import kotlinx.browser.window
 import org.jetbrains.compose.resources.painterResource
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun Smirnov() {
     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -39,9 +41,10 @@ fun Smirnov() {
         )
         Spacer(Modifier.weight(1f))
         Text(
-            modifier = Modifier.onClick(onClick = { 
-                window.open("https://smirnov-studio.com/", "_blank") 
-            }),
+            modifier =
+                Modifier.onClick(onClick = {
+                    window.open("https://smirnov-studio.com/", "_blank")
+                }),
             text =
                 "Design by\n" +
                     "Smirnov Studio",
@@ -51,9 +54,10 @@ fun Smirnov() {
         )
         Spacer(Modifier.size(5.dp))
         Icon(
-            modifier = Modifier.onClick(onClick = { 
-                window.open("https://smirnov-studio.com/", "_blank") 
-            }),
+            modifier =
+                Modifier.onClick(onClick = {
+                    window.open("https://smirnov-studio.com/", "_blank")
+                }),
             imageVector = AntonIcons.Ss,
             contentDescription = "Smirnov",
             tint = Colors.primary,


### PR DESCRIPTION
Add onClick handlers using Modifier.onClick to open external links in Footer, MyProjects, and Smirnov subscreens. This enables proper link navigation in the web/Wasm version.