### PR TITLE
fix: correct Gradle task and publish directory for CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,11 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build for production
-      run: ./gradlew wasmJsBrowserProductionBuild
+      run: ./gradlew wasmJsBrowserDistribution
       
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v4.0.0
       if: success()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./composeApp/build/distributions
+        publish_dir: ./composeApp/build/dist/wasmJs/productionExecutable


### PR DESCRIPTION
- Fix wasmJsBrowserProductionBuild -> wasmJsBrowserDistribution
- Fix publish_dir path to ./composeApp/build/dist/wasmJs/productionExecutable
- Ensure proper build and deployment workflow