### PR TITLE
fix: allow gh-pages push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, master ]
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- grant workflow contents write permission for gh-pages deploy

## Testing
- `CHROME_BIN=/usr/bin/chromium-browser ./gradlew check` *(fails: Errors occurred during launch of browser for testing)*

------
https://chatgpt.com/codex/tasks/task_e_68a61ee2607483208cdc5ffbe44f70b3