### PR TITLE
Add Open Graph metadata

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AntonButov</title>
+    <meta property="og:title" content="Anton Butov – Kotlin Multiplatform Demo" />
+    <meta property="og:description" content="My first web application using Kotlin Multiplatform and Compose Multiplatform." />
+    <meta property="og:image" content="https://antonbutov.com/preview.png" />
+    <meta property="og:url" content="https://antonbutov.com/" />
     <link type="text/css" rel="stylesheet" href="styles.css">
     <script type="application/javascript" src="composeApp.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- add Open Graph tags for title, description, image, and URL in the site index

## Testing
- `./gradlew build` *(fails: Task :kotlinStoreYarnLock FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68ab24a393b083209c65b7844ff05f87