### PR TITLE
Add release build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 This is a Kotlin Multiplatform project targeting Web.
 
-run 
+run
 ```agsl
 ./gradlew wasmJsBrowserDevelopmentRun
 
 ```
+
+## Release build
+
+To generate a production bundle with minification and gzip files run:
+
+```bash
+./scripts/build-release.sh
+```
+
+The optimized files will be placed in `composeApp/build/dist/wasmJs/productionExecutable`.
+Serve these assets with HTTP compression or a CDN to improve the first load time.

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build optimized production bundle
+./gradlew :composeApp:wasmJsBrowserDistribution --console=plain
+
+# Gzip static assets for faster delivery
+DIST_DIR="composeApp/build/dist/wasmJs/productionExecutable"
+if [ -d "$DIST_DIR" ]; then
+  find "$DIST_DIR" -type f -name "*" -exec gzip -kf {} \;
+fi
+
+echo "Distribution is available in $DIST_DIR"
+


### PR DESCRIPTION
## Summary
- add script to build production wasm distribution and gzip assets
- document release build usage in README

## Testing
- `./gradlew check` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b338a01a608320b30544c95fbf4d10