### PR TITLE
Cache Inter font family for faster font loading

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/App.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/App.kt
@@ -21,10 +21,13 @@ import dev.butov.anton.uikit.Message
 @Composable
 fun App() {
     MaterialTheme {
+        // Load Inter font family once and reuse it across recompositions
+        val fontFamily = rememberInterFontFamily()
+
         CompositionLocalProvider(
             LocalTextStyle provides
                 LocalTextStyle.current.copy(
-                    fontFamily = InterFonts(),
+                    fontFamily = fontFamily,
                 ),
             LocalContentColor provides Colors.primary,
         ) {

--- a/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/InterFonts.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/butov/anton/InterFonts.kt
@@ -1,6 +1,7 @@
 package dev.butov.anton
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import antonbutov.composeapp.generated.resources.Inter_28pt_Light
@@ -9,19 +10,14 @@ import antonbutov.composeapp.generated.resources.Inter_28pt_Regular
 import antonbutov.composeapp.generated.resources.Res
 import org.jetbrains.compose.resources.Font
 
+/**
+ * Returns a cached instance of the Inter [FontFamily].
+ * The fonts are requested only once and reused on subsequent recompositions.
+ */
 @Composable
-fun InterFonts() =
-    FontFamily(
-        Font(
-            resource = Res.font.Inter_28pt_Regular,
-            weight = FontWeight.Normal,
-        ),
-        Font(
-            resource = Res.font.Inter_28pt_Medium,
-            weight = FontWeight.Medium,
-        ),
-        Font(
-            resource = Res.font.Inter_28pt_Light,
-            weight = FontWeight.Light,
-        ),
-    )
+fun rememberInterFontFamily(): FontFamily {
+    val regular = Font(resource = Res.font.Inter_28pt_Regular, weight = FontWeight.Normal)
+    val medium = Font(resource = Res.font.Inter_28pt_Medium, weight = FontWeight.Medium)
+    val light = Font(resource = Res.font.Inter_28pt_Light, weight = FontWeight.Light)
+    return remember { FontFamily(regular, medium, light) }
+}


### PR DESCRIPTION
## Summary
- Cache Inter `FontFamily` via `rememberInterFontFamily` to prevent repeated font requests
- Use cached font family in `App` so fonts load once during initialization

## Testing
- `./gradlew build` *(fails: Critical dependency: the request of a dependency is an expression)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d9514a0883208a4443170a3aa9a2