### PR TITLE
feat: preload wasm modules

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -8,6 +8,8 @@
     <meta property="og:description" content="My first web application using Kotlin Multiplatform and Compose Multiplatform." />
     <meta property="og:image" content="https://antonbutov.com/preview.png" />
     <meta property="og:url" content="https://antonbutov.com/" />
+    <link rel="preload" href="composeApp.wasm" as="fetch" type="application/wasm" crossorigin="anonymous">
+    <link rel="preload" href="skiko.wasm" as="fetch" type="application/wasm" crossorigin="anonymous">
     <link type="text/css" rel="stylesheet" href="styles.css">
     
     <!-- Add loading optimization -->


### PR DESCRIPTION
## Summary
- preload wasm modules so they load in parallel with the JS bundle

## Testing
- `./gradlew build` *(fails: ChromeHeadless not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b96e80bbdc8320a84362f81d41c45a