### PR TITLE
Improve WASM bootstrap fetch deduplication

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -42,8 +42,101 @@
     
     <!-- Preload critical resources for faster cold start -->
     <link rel="preload" href="composeApp.js" as="script">
-    <link rel="preload" href="composeApp.wasm" as="fetch" type="application/wasm" crossorigin>
-    <link rel="preload" href="skiko.wasm" as="fetch" type="application/wasm" crossorigin>
+
+    <!-- Optimistic parallel WASM fetch without duplicate downloads -->
+    <script>
+        (function () {
+            if (typeof window === 'undefined' || typeof window.fetch !== 'function') {
+                return;
+            }
+
+            const nativeFetch = window.fetch.bind(window);
+            const normalizeUrl = (input) => {
+                try {
+                    return new URL(input, window.location.href).href;
+                } catch (_) {
+                    return null;
+                }
+            };
+
+            const shouldHandle = (absoluteUrl) => {
+                if (!absoluteUrl) {
+                    return false;
+                }
+                try {
+                    const parsed = new URL(absoluteUrl);
+                    return (
+                        parsed.origin === window.location.origin &&
+                        parsed.pathname.endsWith('.wasm')
+                    );
+                } catch (_) {
+                    return false;
+                }
+            };
+
+            const wasmFetches = new Map();
+            const track = (url, promise) => {
+                const tracked = promise
+                    .then((response) => {
+                        if (!response || !response.ok) {
+                            wasmFetches.delete(url);
+                        }
+                        return response;
+                    })
+                    .catch((error) => {
+                        wasmFetches.delete(url);
+                        throw error;
+                    });
+                wasmFetches.set(url, tracked);
+                return tracked;
+            };
+
+            const warmupTargets = ['composeApp.wasm', 'skiko.wasm']
+                .map(normalizeUrl)
+                .filter((url, index, array) => url && array.indexOf(url) === index);
+
+            warmupTargets.forEach((url) => {
+                track(url, nativeFetch(url, { credentials: 'same-origin' })).catch(() => {
+                    /* Warmup failures fall back to runtime fetches. */
+                });
+            });
+
+            const extractUrl = (input) => {
+                if (typeof input === 'string') {
+                    return input;
+                }
+                if (input && typeof input === 'object' && 'url' in input) {
+                    return input.url;
+                }
+                return null;
+            };
+
+            window.fetch = async (input, init) => {
+                const requested = extractUrl(input);
+                const absoluteUrl = normalizeUrl(requested);
+
+                if (shouldHandle(absoluteUrl)) {
+                    const existing = wasmFetches.get(absoluteUrl);
+                    if (existing) {
+                        const response = await existing;
+                        if (!response) {
+                            return nativeFetch(input, init);
+                        }
+                        return response.clone();
+                    }
+
+                    const pending = track(absoluteUrl, nativeFetch(input, init));
+                    const response = await pending;
+                    if (!response || !response.ok) {
+                        return response;
+                    }
+                    return response.clone();
+                }
+
+                return nativeFetch(input, init);
+            };
+        })();
+    </script>
     
     <!-- Images are now loaded asynchronously with AsyncImage component -->
     <!-- This provides better performance by loading images only when needed -->


### PR DESCRIPTION
## Summary
- remove redundant WASM `<link rel="preload">` entries that triggered duplicate downloads
- replace them with a bootstrap script that warms composeApp.wasm/skiko.wasm in parallel and deduplicates all `.wasm` fetches (including the hashed filenames emitted by CI)

## Testing
- ./gradlew wasmJsBrowserDistribution --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e9e6a5bef4832090a755180005dba2